### PR TITLE
Feature | Remove Auth

### DIFF
--- a/src/events/controllers/events.controller.ts
+++ b/src/events/controllers/events.controller.ts
@@ -46,8 +46,6 @@ export class EventsController {
     this.logger.setContext(EventsController.name);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @UseInterceptors(ClassSerializerInterceptor)
   @Get()
   @ApiOperation({
@@ -96,8 +94,6 @@ export class EventsController {
     return { data: event, meta: {} };
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @UseInterceptors(ClassSerializerInterceptor)
   @Get("/:id")
   @ApiOperation({

--- a/src/opportunity/controllers/opportunities.controller.ts
+++ b/src/opportunity/controllers/opportunities.controller.ts
@@ -46,8 +46,6 @@ export class OpportunityController {
     this.logger.setContext(OpportunityController.name);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @UseInterceptors(ClassSerializerInterceptor)
   @Get()
   @ApiOperation({
@@ -97,8 +95,6 @@ export class OpportunityController {
     return { data: item, meta: {} };
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @UseInterceptors(ClassSerializerInterceptor)
   @Get("/:id")
   @ApiOperation({

--- a/src/organization/controllers/organization.controller.ts
+++ b/src/organization/controllers/organization.controller.ts
@@ -47,8 +47,6 @@ export class OrganizationController {
     this.logger.setContext(OrganizationController.name);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @UseInterceptors(ClassSerializerInterceptor)
   @Get()
   @ApiOperation({
@@ -101,8 +99,6 @@ export class OrganizationController {
     return { data: organization, meta: {} };
   }
 
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @UseInterceptors(ClassSerializerInterceptor)
   @Get("/:id")
   @ApiOperation({


### PR DESCRIPTION
chore: remove JwtAuthGuard and ApiBearerAuth from event, opportunity, and organization controllers

This pull request removes the `JwtAuthGuard` and `ApiBearerAuth` decorators from several controller methods across the application. These changes appear to relax authentication requirements for specific endpoints.

### Authentication changes:

* `src/events/controllers/events.controller.ts`:
  - Removed `JwtAuthGuard` and `ApiBearerAuth` from the `@Get()` method.
  - Removed `JwtAuthGuard` and `ApiBearerAuth` from the `@Get("/:id")` method.

* `src/opportunity/controllers/opportunities.controller.ts`:
  - Removed `JwtAuthGuard` and `ApiBearerAuth` from the `@Get()` method.
  - Removed `JwtAuthGuard` and `ApiBearerAuth` from the `@Get("/:id")` method.

* `src/organization/controllers/organization.controller.ts`:
  - Removed `JwtAuthGuard` and `ApiBearerAuth` from the `@Get()` method.
  - Removed `JwtAuthGuard` and `ApiBearerAuth` from the `@Get("/:id")` method.