### PR TITLE
feat: add daily prompt rate limiting , chat sidebar, rename /delete button

### DIFF
--- a/prisma/migrations/20260222195718_add_linkedin_to_user/migration.sql
+++ b/prisma/migrations/20260222195718_add_linkedin_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "linkedin" TEXT;

--- a/src/ai-assistant/controllers/ai-assistant.controller.ts
+++ b/src/ai-assistant/controllers/ai-assistant.controller.ts
@@ -72,6 +72,19 @@ export class AiAssistantController {
     return { data: sessions, meta: {} };
   }
 
+  @Get("usage")
+  @ApiOperation({ summary: "Get daily prompt usage for the current user" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Returns daily prompt usage (used, limit, remaining)",
+  })
+  async getUsage(
+    @ReqContext() ctx: RequestContext
+  ): Promise<BaseApiResponse<any>> {
+    const usage = await this.aiAssistantService.getDailyUsage(ctx);
+    return { data: usage, meta: {} };
+  }
+
   @Get("sessions/:sessionId/messages")
   @ApiOperation({ summary: "Get all messages for a chat session" })
   @ApiResponse({

--- a/src/ai-assistant/services/ai-assistant.service.ts
+++ b/src/ai-assistant/services/ai-assistant.service.ts
@@ -1,10 +1,12 @@
-import { Injectable, NotFoundException, ForbiddenException, UnauthorizedException } from "@nestjs/common";
+import { Injectable, NotFoundException, ForbiddenException, UnauthorizedException, HttpException, HttpStatus } from "@nestjs/common";
 import { HttpService } from "@nestjs/axios";
 import { firstValueFrom } from "rxjs";
 import { v4 as uuidv4 } from "uuid";
 import { PrismaService } from "../../shared/prisma-module/prisma.service";
 import { AppLogger } from "../../shared/logger/logger.service";
 import { RequestContext } from "../../shared/request-context/request-context.dto";
+
+const DAILY_PROMPT_LIMIT = 3;
 
 const RAG_SERVICE_URL = process.env.RAG_SERVICE_URL || "http://localhost:8000";
 
@@ -28,6 +30,29 @@ export class AiAssistantService {
       throw new UnauthorizedException("User not authenticated");
     }
     return ctx.user.id;
+  }
+
+  /**
+   * Get how many prompts the user has used today (UTC midnight reset)
+   */
+  async getDailyUsage(ctx: RequestContext) {
+    const userId = this.getUserId(ctx);
+    const todayStart = new Date();
+    todayStart.setUTCHours(0, 0, 0, 0);
+
+    const count = await this.prismaService.chat_messages.count({
+      where: {
+        role: 'user',
+        created_at: { gte: todayStart },
+        chat_sessions: { user_id: userId },
+      },
+    });
+
+    return {
+      used: count,
+      limit: DAILY_PROMPT_LIMIT,
+      remaining: Math.max(0, DAILY_PROMPT_LIMIT - count),
+    };
   }
 
   /**
@@ -323,6 +348,21 @@ export class AiAssistantService {
   ) {
     const userId = this.getUserId(ctx);
     this.logger.log(ctx, `Chat request from user ${userId}: "${query.substring(0, 50)}..."`);
+
+    // Rate-limit check: 3 prompts per day (admins exempt)
+    const isAdmin = ctx.user?.isSuperAdmin === true;
+    if (!isAdmin) {
+      const usage = await this.getDailyUsage(ctx);
+      if (usage.remaining <= 0) {
+        throw new HttpException(
+          {
+            message: `Daily prompt limit reached (${usage.limit}/${usage.limit}). Try again tomorrow!`,
+            usage,
+          },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+    }
 
     // Create or use existing session
     let sessionId = conversationId;


### PR DESCRIPTION
- Adds 3 prompts/day rate limit (admins exempt) with GET /usage endpoint. 
- Adds chat session management: sidebar history, rename and delete session endpoints. 
